### PR TITLE
captureの停止ボタン実装

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { useCallback, useRef, useState, useEffect } from "react";
 import "./styles.css";
 import "@tensorflow/tfjs";
 import * as handPoseDetection from "@tensorflow-models/hand-pose-detection";
@@ -7,13 +7,13 @@ import { Canvas } from "@react-three/fiber";
 import { Hand } from "./Hand";
 
 export default function App() {
-  const webcamRef = React.useRef(null);
-  const modelRef = React.useRef(null);
-  const requestRef = React.useRef(null);
-  const predictionsRef = React.useRef(null);
-  const [ready, setReady] = React.useState(false);
+  const webcamRef = useRef(null);
+  const modelRef = useRef(null);
+  const requestRef = useRef(null);
+  const predictionsRef = useRef(null);
+  const [ready, setReady] = useState(false);
 
-  const capture = React.useCallback(async () => {
+  const capture = useCallback(async () => {
     if (webcamRef.current && modelRef.current) {
       const predictions = await modelRef.current.estimateHands(
         webcamRef.current.getCanvas()
@@ -24,14 +24,16 @@ export default function App() {
       }
     }
 
+    // ready stateが更新されてもなお同じreadyの値がよばれ続けてしまう
     if (ready) {
       requestRef.current = requestAnimationFrame(capture);
     } else {
+      //not working
       requestRef.current = null;
     }
   }, [ready]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const load = async () => {
       const model = handPoseDetection.SupportedModels.MediaPipeHands;
       const detectorConfig = {
@@ -47,13 +49,13 @@ export default function App() {
     load();
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ready) {
       requestRef.current = requestAnimationFrame(capture);
     } else {
       if (requestRef.current) {
         console.log("cancel");
-        cancelAnimationFrame(requestRef.current);
+        cancelAnimationFrame(requestRef.current); //not working
       }
     }
   }, [ready]);

--- a/src/Finger.js
+++ b/src/Finger.js
@@ -1,0 +1,61 @@
+import React from "react";
+import "./styles.css";
+import "@tensorflow/tfjs";
+import { useFrame } from "@react-three/fiber";
+
+const scale = (point) => -(point * 800) / 50;
+
+export const Finger = ({ predictionsRef, fingerIndex }) => {
+  const jointBottom = React.useRef();
+  const jointMiddleBottom = React.useRef();
+  const jointMiddleTop = React.useRef();
+  const jointTop = React.useRef();
+
+  const updateJoint = (point, thumb) => {
+    thumb.current.position.x = -scale(point.x);
+    thumb.current.position.y = scale(point.y);
+    thumb.current.position.z = scale(point.z);
+  };
+
+  useFrame(() => {
+    if (predictionsRef.current.length) {
+      updateJoint(
+        predictionsRef.current[0].keypoints3D[Number(fingerIndex)],
+        jointBottom
+      );
+      updateJoint(
+        predictionsRef.current[0].keypoints3D[Number(fingerIndex) + 1],
+        jointMiddleBottom
+      );
+      updateJoint(
+        predictionsRef.current[0].keypoints3D[Number(fingerIndex) + 2],
+        jointMiddleTop
+      );
+      updateJoint(
+        predictionsRef.current[0].keypoints3D[Number(fingerIndex) + 3],
+        jointTop
+      );
+    }
+  });
+
+  return (
+    <>
+      <mesh castShadow receiveShadow ref={jointBottom} scale={[1, 1, 1]}>
+        <sphereBufferGeometry attach="geometry" args={[0.1, 32, 32]} />
+        <meshStandardMaterial attach="material" color="white" />
+      </mesh>
+      <mesh castShadow receiveShadow ref={jointMiddleBottom} scale={[1, 1, 1]}>
+        <sphereBufferGeometry attach="geometry" args={[0.1, 32, 32]} />
+        <meshStandardMaterial attach="material" color="white" />
+      </mesh>
+      <mesh castShadow receiveShadow ref={jointMiddleTop} scale={[1, 1, 1]}>
+        <sphereBufferGeometry attach="geometry" args={[0.1, 32, 32]} />
+        <meshStandardMaterial attach="material" color="white" />
+      </mesh>
+      <mesh castShadow receiveShadow ref={jointTop} scale={[1, 1, 1]}>
+        <sphereBufferGeometry attach="geometry" args={[0.1, 32, 32]} />
+        <meshStandardMaterial attach="material" color="#eb3b5a" />
+      </mesh>
+    </>
+  );
+};

--- a/src/Hand.js
+++ b/src/Hand.js
@@ -1,0 +1,33 @@
+import React from "react";
+import "./styles.css";
+import "@tensorflow/tfjs";
+import { useFrame } from "@react-three/fiber";
+import { Finger } from "./Finger";
+const scale = (point) => -(point * 800) / 50;
+
+export const Hand = ({ predictionsRef }) => {
+  const palm = React.useRef();
+
+  useFrame(() => {
+    if (predictionsRef.current.length) {
+      const point = predictionsRef.current[0].keypoints3D[0];
+      palm.current.position.x = -scale(point.x);
+      palm.current.position.y = scale(point.y);
+      palm.current.position.z = scale(point.z);
+    }
+  });
+
+  return (
+    <>
+      <mesh castShadow receiveShadow ref={palm} scale={[1, 1, 1]}>
+        <sphereBufferGeometry attach="geometry" args={[0.1, 32, 32]} />
+        <meshStandardMaterial attach="material" color="#3867d6" />
+      </mesh>
+      <Finger predictionsRef={predictionsRef} fingerIndex="1" />
+      <Finger predictionsRef={predictionsRef} fingerIndex="5" />
+      <Finger predictionsRef={predictionsRef} fingerIndex="9" />
+      <Finger predictionsRef={predictionsRef} fingerIndex="13" />
+      <Finger predictionsRef={predictionsRef} fingerIndex="17" />
+    </>
+  );
+};


### PR DESCRIPTION
captureの停止ボタンを実装した。これによってボタンを押すと手のアニメーションが「表示されなくなる＝処理はバックグラウンドで動き続けている」。
当初の予定としては、cancelボタンが押されると同時にcapture関数がループで呼ばれることを停止しようとしていたのだが、どうもうまくいっていない... stateが更新されてもuseCallbackの関数が再計算されないみたい。

```javascript
  const capture = useCallback(async () => {
    if (webcamRef.current && modelRef.current) {
      const predictions = await modelRef.current.estimateHands(
        webcamRef.current.getCanvas()
      );

      if (predictions) {
        predictionsRef.current = predictions;
      }
    }

    // ready stateが更新されてもなお同じreadyの値がよばれ続けてしまう
    if (ready) {
      requestRef.current = requestAnimationFrame(capture);
    } else {
      //not working
      requestRef.current = null;
    }
  }, [ready]);
```
```javascript

  useEffect(() => {
    if (ready) {
      requestRef.current = requestAnimationFrame(capture);
    } else {
      if (requestRef.current) {
        console.log("cancel");
        cancelAnimationFrame(requestRef.current); //not working
      }
    }
  }, [ready]);
```

### 参考記事
https://stackoverflow.com/questions/62653091/cancelling-requestanimationrequest-in-a-react-component-using-hooks-doesnt-work